### PR TITLE
Fix NPE in findDeployedLabels() when environment is launching

### DIFF
--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
@@ -130,9 +130,11 @@ public class BeanstalkDeployer {
         req.setApplicationName(applicationName);
 
         Set<String> result = new TreeSet<String>();
-        for (EnvironmentDescription description : elasticBeanstalk.describeEnvironments(req).getEnvironments())
-            result.add(description.getVersionLabel());
-
+        for (EnvironmentDescription description : elasticBeanstalk.describeEnvironments(req).getEnvironments()) {
+            if (description.getVersionLabel() != null) { // Ignore null value (for example when environment is launching)
+                result.add(description.getVersionLabel());
+            }
+        }
         return result;
     }
 }


### PR DESCRIPTION
When environment is launching, environment description might return null value for version label.
