### PR TITLE
Automatically create app environment if it does not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ First, create `~/.aws/credentials` with a profile for your app:
     aws_access_key_id=YOUR_ACCESS_KEY_ID
     aws_secret_access_key=YOUR_SECRET_ACCESS_KEY
 
+Or set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+
 Next, configure some deployments in your `build.gradle`:
 
     plugins {
@@ -17,21 +19,23 @@ Next, configure some deployments in your `build.gradle`:
     }
 
     beanstalk {
-        profile = 'my-profile'
+        profile = 'my-profile' // Only required if using .aws/credentials
         s3Endpoint = "s3-eu-west-1.amazonaws.com"
         beanstalkEndpoint = "elasticbeanstalk.eu-west-1.amazonaws.com"
     
         deployments {
+            // Example to deploy to the same env
             staging {
                 war = tasks.war
                 application = 'my-app'
                 environment = 'my-app-staging'
             }
-    
+            // Example to create a new env for each version (to use URL swapping for blue/green deployment)
             production {
                 war = tasks.productionWar
                 application = 'my-app'
-                environment = 'my-app-production'
+                environment = "my-app-${project.version.replaceAll('\\.', '-')}"
+                template = 'default' // Saved configuration name to use to create each env
             }
         }
     }

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
@@ -5,6 +5,7 @@ public class BeanstalkDeployment {
     private final String name;
     private String application;
     private String environment;
+    private String template = "default";
     private Object war;
 
     public BeanstalkDeployment(String name) {
@@ -29,6 +30,14 @@ public class BeanstalkDeployment {
 
     public void setEnvironment(String environment) {
         this.environment = environment;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(String template) {
+        this.template = template;
     }
 
     public Object getWar() {

--- a/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
@@ -31,7 +31,7 @@ public class DeployTask extends DefaultTask {
         BeanstalkDeployer deployer = new BeanstalkDeployer(beanstalk.getS3Endpoint(), beanstalk.getBeanstalkEndpoint(), credentialsProvider);
 
         File warFile = getProject().files(war).getSingleFile();
-        deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), versionLabel);
+        deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), deployment.getTemplate(), versionLabel);
     }
 
     public void setBeanstalk(BeanstalkPluginExtension beanstalk) {


### PR DESCRIPTION
Our build pipeline:
- **beta/staging** -> upload to the same env (with downtime)
- **prod** -> create a new env for each version and use URL swapping for blue/green deployment (no downtime).

The plugin has been updated to enable this behaviour.
First, the plugin will check if the env exists, if it doesn't, it will create it.
An additional config param `template` has been added to define which saved configuration to use when creating new env.

What do you think?
