### PR TITLE
Additional parameter to defined the number of versions to keep

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Next, configure some deployments in your `build.gradle`:
         profile = 'my-profile'
         s3Endpoint = "s3-eu-west-1.amazonaws.com"
         beanstalkEndpoint = "elasticbeanstalk.eu-west-1.amazonaws.com"
+        versionsToKeep = 20 // Optional, if set, old versions will be deleted
     
         deployments {
             staging {

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkPluginExtension.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkPluginExtension.java
@@ -5,6 +5,7 @@ public class BeanstalkPluginExtension {
     private String profile;
     private String s3Endpoint;
     private String beanstalkEndpoint;
+    private Integer versionsToKeep;
 
     public String getProfile() {
         return profile;
@@ -28,5 +29,13 @@ public class BeanstalkPluginExtension {
 
     public void setBeanstalkEndpoint(String beanstalkEndpoint) {
         this.beanstalkEndpoint = beanstalkEndpoint;
+    }
+
+    public Integer getVersionsToKeep() {
+        return versionsToKeep;
+    }
+
+    public void setVersionsToKeep(Integer versionsToKeep) {
+        this.versionsToKeep = versionsToKeep;
     }
 }

--- a/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
@@ -31,7 +31,7 @@ public class DeployTask extends DefaultTask {
         BeanstalkDeployer deployer = new BeanstalkDeployer(beanstalk.getS3Endpoint(), beanstalk.getBeanstalkEndpoint(), credentialsProvider);
 
         File warFile = getProject().files(war).getSingleFile();
-        deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), versionLabel);
+        deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), versionLabel, beanstalk.getVersionsToKeep());
     }
 
     public void setBeanstalk(BeanstalkPluginExtension beanstalk) {


### PR DESCRIPTION
New config param `versionsToKeep` to define the number of versions to keep when cleaning app versions after deployment.

It is currently hardcoded as 20, so I thought it would be nice to be able to adjust this settings or disable it.
