### PR TITLE
Added functionality to deploy using delegate role capability of AWS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build
 .gradle
 .idea/workspace.xml
+
+bin
+.classpath

--- a/.project
+++ b/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gradle-beanstalk-plugin</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.springsource.ide.eclipse.gradle.core.nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/gradle/org.springsource.ide.eclipse.gradle.core.prefs
+++ b/.settings/gradle/org.springsource.ide.eclipse.gradle.core.prefs
@@ -1,0 +1,4 @@
+#org.springsource.ide.eclipse.gradle.core.preferences.GradleProjectPreferences
+#Thu Sep 10 10:34:28 CEST 2015
+org.springsource.ide.eclipse.gradle.linkedresources=
+org.springsource.ide.eclipse.gradle.rootprojectloc=

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,13 @@
+#
+#Tue Sep 29 11:55:12 CEST 2015
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,33 @@ plugins {
     id "com.gradle.plugin-publish" version "0.9.1"
 }
 
+apply plugin: 'maven'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'eclipse'
+   
+def env = System.getenv()
+def nexusUser = env['nexusUser']
+def nexusPassword = env['nexusPassword']
 repositories {
     jcenter()
+    mavenLocal()
+    mavenCentral()
+    maven { url "https://repo.spring.io/libs-release" }
+    maven { url =  "http://nexus.ebgroup.elektrobit.com:8080/nexus/content/groups/public/" }
+    maven {
+        url = "http://nexus.ebgroup.elektrobit.com:8080/nexus/content/repositories/accelera.snapshots/"
+        credentials {
+            username nexusUser
+            password nexusPassword
+        }
+    }
+    maven {
+        url = "http://nexus.ebgroup.elektrobit.com:8080/nexus/content/repositories/accelera.releases/"
+        credentials {
+            username nexusUser
+            password nexusPassword
+        }
+    }
 }
 
 ext {
@@ -19,8 +42,8 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-sts:$awsApiVersion"
 }
 
-group = 'fi.evident.gradle.beanstalk'
-version '0.0.61'
+group = 'com.elektrobit.odin'
+version '0.0.65'
 
 pluginBundle {
     website = 'https://github.com/EvidentSolutions/gradle-beanstalk-plugin'
@@ -34,4 +57,15 @@ pluginBundle {
             displayName = 'Gradle Beanstalk plugin'
         }
     }
+}
+
+uploadArchives {
+	repositories.mavenDeployer {
+		repository(url :  "http://nexus.ebgroup.elektrobit.com:8080/nexus/content/repositories/con.releases/"){
+			authentication(userName: nexusUser, password: nexusPassword)
+		}
+		snapshotRepository(url :  "http://nexus.ebgroup.elektrobit.com:8080/nexus/content/repositories/con.snapshots/"){
+			authentication(userName: nexusUser, password: nexusPassword)
+		}
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 }
 
 group = 'fi.evident.gradle.beanstalk'
-version '0.0.6'
+version '0.0.61'
 
 pluginBundle {
     website = 'https://github.com/EvidentSolutions/gradle-beanstalk-plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 apply plugin: 'java-gradle-plugin'
-
+apply plugin: 'eclipse'
 repositories {
     jcenter()
 }
@@ -15,6 +15,8 @@ ext {
 dependencies {
     compile "com.amazonaws:aws-java-sdk-elasticbeanstalk:$awsApiVersion"
     compile "com.amazonaws:aws-java-sdk-s3:$awsApiVersion"
+    compile "com.amazonaws:aws-java-sdk-core:$awsApiVersion"
+    compile "com.amazonaws:aws-java-sdk-sts:$awsApiVersion"
 }
 
 group = 'fi.evident.gradle.beanstalk'

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
@@ -29,13 +29,6 @@ public class BeanstalkDeployer {
 
     private static final Logger log = LoggerFactory.getLogger(BeanstalkDeployer.class);
 
-    public BeanstalkDeployer(String s3Endpoint, String beanstalkEndpoint, AWSCredentialsProvider credentialsProvider) {
-        s3 = new AmazonS3Client(credentialsProvider);
-        elasticBeanstalk = new AWSElasticBeanstalkClient(credentialsProvider);
-        s3.setEndpoint(s3Endpoint);
-        elasticBeanstalk.setEndpoint(beanstalkEndpoint);
-    }
-    
     public BeanstalkDeployer(String s3Endpoint, String beanstalkEndpoint, AWSCredentials awsCredentials) {
         s3 = new AmazonS3Client(awsCredentials);
         elasticBeanstalk = new AWSElasticBeanstalkClient(awsCredentials);

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
@@ -1,11 +1,13 @@
 package fi.evident.gradle.beanstalk;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClient;
 import com.amazonaws.services.elasticbeanstalk.model.*;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +32,13 @@ public class BeanstalkDeployer {
     public BeanstalkDeployer(String s3Endpoint, String beanstalkEndpoint, AWSCredentialsProvider credentialsProvider) {
         s3 = new AmazonS3Client(credentialsProvider);
         elasticBeanstalk = new AWSElasticBeanstalkClient(credentialsProvider);
+        s3.setEndpoint(s3Endpoint);
+        elasticBeanstalk.setEndpoint(beanstalkEndpoint);
+    }
+    
+    public BeanstalkDeployer(String s3Endpoint, String beanstalkEndpoint, AWSCredentials awsCredentials) {
+        s3 = new AmazonS3Client(awsCredentials);
+        elasticBeanstalk = new AWSElasticBeanstalkClient(awsCredentials);
         s3.setEndpoint(s3Endpoint);
         elasticBeanstalk.setEndpoint(beanstalkEndpoint);
     }

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
@@ -1,6 +1,5 @@
 package fi.evident.gradle.beanstalk;
 
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClient;
@@ -29,9 +28,9 @@ public class BeanstalkDeployer {
 
     private static final Logger log = LoggerFactory.getLogger(BeanstalkDeployer.class);
 
-    public BeanstalkDeployer(String s3Endpoint, String beanstalkEndpoint, AWSCredentials awsCredentials) {
-        s3 = new AmazonS3Client(awsCredentials);
-        elasticBeanstalk = new AWSElasticBeanstalkClient(awsCredentials);
+    public BeanstalkDeployer(String s3Endpoint, String beanstalkEndpoint, AWSCredentialsProvider credentialsProvider) {
+        s3 = new AmazonS3Client(credentialsProvider);
+        elasticBeanstalk = new AWSElasticBeanstalkClient(credentialsProvider);
         s3.setEndpoint(s3Endpoint);
         elasticBeanstalk.setEndpoint(beanstalkEndpoint);
     }

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
@@ -7,7 +7,9 @@ public class BeanstalkDeployment {
     private String environment;
     private String template = "default";
     private Object war;
-
+    private String account;
+    private String arnRole;
+    
     public BeanstalkDeployment(String name) {
         this.name = name;
     }
@@ -46,5 +48,21 @@ public class BeanstalkDeployment {
 
     public void setWar(Object war) {
         this.war = war;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public void setAccount(String account) {
+        this.account = account;
+    }
+
+    public String getArnRole() {
+        return arnRole;
+    }
+
+    public void setArnRole(String arnRole) {
+        this.arnRole = arnRole;
     }
 }

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
@@ -9,6 +9,8 @@ public class BeanstalkDeployment {
     private Object war;
     private String account;
     private String arnRole;
+    private String s3Endpoint;
+    private String beanstalkEndpoint;
     
     public BeanstalkDeployment(String name) {
         this.name = name;
@@ -64,5 +66,21 @@ public class BeanstalkDeployment {
 
     public void setArnRole(String arnRole) {
         this.arnRole = arnRole;
+    }
+
+    public String getS3Endpoint() {
+        return s3Endpoint;
+    }
+
+    public void setS3Endpoint(String s3Endpoint) {
+        this.s3Endpoint = s3Endpoint;
+    }
+
+    public String getBeanstalkEndpoint() {
+        return beanstalkEndpoint;
+    }
+
+    public void setBeanstalkEndpoint(String beanstalkEndpoint) {
+        this.beanstalkEndpoint = beanstalkEndpoint;
     }
 }

--- a/src/main/java/fi/evident/gradle/beanstalk/CredentialUtility.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/CredentialUtility.java
@@ -8,6 +8,7 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
@@ -16,17 +17,18 @@ import com.amazonaws.services.securitytoken.model.Credentials;
 public class CredentialUtility {
     private static final String DEFAULT = "default";
 
-    public static AWSCredentials getAssumeRoleCredentials(String arnRole, String sessionName) {
+    public static StaticCredentialsProvider getAssumeRoleCredentials(String arnRole, String sessionName) {
         AWSCredentialsProviderChain awsCredentialsProvider = new AWSCredentialsProviderChain(new ClasspathPropertiesFileCredentialsProvider(), new EnvironmentVariableCredentialsProvider(), new SystemPropertiesCredentialsProvider(), new InstanceProfileCredentialsProvider(), new ProfileCredentialsProvider(DEFAULT));
         AWSCredentials defaultCredentials = awsCredentialsProvider.getCredentials();
+        System.out.println(defaultCredentials.getAWSAccessKeyId());
         return CredentialUtility.getSessionCredentialsForRole(arnRole, sessionName, defaultCredentials);
     }
 
-    public static BasicSessionCredentials getSessionCredentialsForRole(String arnRole, String sessionName, AWSCredentials awsCredentials) {
+    public static StaticCredentialsProvider getSessionCredentialsForRole(String arnRole, String sessionName, AWSCredentials awsCredentials) {
         AWSSecurityTokenServiceClient stsClient = new AWSSecurityTokenServiceClient(awsCredentials);
         AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(arnRole).withDurationSeconds(3600).withRoleSessionName(sessionName);
         AssumeRoleResult assumeResult = stsClient.assumeRole(assumeRequest);
-        Credentials credentials =assumeResult.getCredentials();
-        return new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
+        Credentials credentials = assumeResult.getCredentials();
+        return new StaticCredentialsProvider(new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken()));
     }
 }

--- a/src/main/java/fi/evident/gradle/beanstalk/CredentialUtility.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/CredentialUtility.java
@@ -1,0 +1,32 @@
+package fi.evident.gradle.beanstalk;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
+import com.amazonaws.services.securitytoken.model.Credentials;
+
+public class CredentialUtility {
+    private static final String DEFAULT = "default";
+
+    public static AWSCredentials getAssumeRoleCredentials(String arnRole, String sessionName) {
+        AWSCredentialsProviderChain awsCredentialsProvider = new AWSCredentialsProviderChain(new ClasspathPropertiesFileCredentialsProvider(), new EnvironmentVariableCredentialsProvider(), new SystemPropertiesCredentialsProvider(), new InstanceProfileCredentialsProvider(), new ProfileCredentialsProvider(DEFAULT));
+        AWSCredentials defaultCredentials = awsCredentialsProvider.getCredentials();
+        return CredentialUtility.getSessionCredentialsForRole(arnRole, sessionName, defaultCredentials);
+    }
+
+    public static BasicSessionCredentials getSessionCredentialsForRole(String arnRole, String sessionName, AWSCredentials awsCredentials) {
+        AWSSecurityTokenServiceClient stsClient = new AWSSecurityTokenServiceClient(awsCredentials);
+        AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(arnRole).withDurationSeconds(3600).withRoleSessionName(sessionName);
+        AssumeRoleResult assumeResult = stsClient.assumeRole(assumeRequest);
+        Credentials credentials =assumeResult.getCredentials();
+        return new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
+    }
+}

--- a/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
@@ -32,15 +32,15 @@ public class DeployTask extends DefaultTask {
         }
 
         AWSCredentials awsCredentials;
-        if (deployment.getAccount().equals(beanstalk.getProfile())) {
+        if (deployment.getAccount()==null || deployment.getAccount().isEmpty()) {
             AWSCredentialsProviderChain credentialsProviderChain = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider(), new SystemPropertiesCredentialsProvider(), new ProfileCredentialsProvider(beanstalk.getProfile()));
             awsCredentials = credentialsProviderChain.getCredentials();
         }else{
-            System.out.println(deployment.getArnRole());
             awsCredentials =  CredentialUtility.getAssumeRoleCredentials(deployment.getArnRole(), deployment.getAccount());
-            log.info("Obtained credentials using arnRole {} for account {}",deployment.getArnRole() , deployment.getAccount());
+            log.info("Obtained credentials using arnRole {} for account {}", deployment.getArnRole() , deployment.getAccount());
+            beanstalk.setBeanstalkEndpoint(deployment.getBeanstalkEndpoint());
+            beanstalk.setS3Endpoint(deployment.getS3Endpoint());
         }
-
         BeanstalkDeployer deployer = new BeanstalkDeployer(beanstalk.getS3Endpoint(), beanstalk.getBeanstalkEndpoint(), awsCredentials);
         File warFile = getProject().files(war).getSingleFile();
         deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), deployment.getTemplate(), versionLabel);

--- a/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
@@ -38,10 +38,10 @@ public class DeployTask extends DefaultTask {
         }else{
             awsCredentials =  CredentialUtility.getAssumeRoleCredentials(deployment.getArnRole(), deployment.getAccount());
             log.info("Obtained credentials using arnRole {} for account {}", deployment.getArnRole() , deployment.getAccount());
-            beanstalk.setBeanstalkEndpoint(deployment.getBeanstalkEndpoint());
-            beanstalk.setS3Endpoint(deployment.getS3Endpoint());
         }
-        BeanstalkDeployer deployer = new BeanstalkDeployer(beanstalk.getS3Endpoint(), beanstalk.getBeanstalkEndpoint(), awsCredentials);
+        String s3Endpoint = Utilities.coalesce(deployment.getS3Endpoint(),beanstalk.getS3Endpoint());
+        String beanstalkEndpoint =Utilities.coalesce(deployment.getBeanstalkEndpoint(),beanstalk.getBeanstalkEndpoint());
+        BeanstalkDeployer deployer = new BeanstalkDeployer(s3Endpoint, beanstalkEndpoint, awsCredentials);
         File warFile = getProject().files(war).getSingleFile();
         deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), deployment.getTemplate(), versionLabel);
     }

--- a/src/main/java/fi/evident/gradle/beanstalk/Utilities.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/Utilities.java
@@ -1,0 +1,12 @@
+package fi.evident.gradle.beanstalk;
+
+public class Utilities {
+    public static String coalesce(String... items) {
+        for (String i : items) {
+            if (i != null) {
+                return i;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
I have added the functionality to use the delegate role concept of AWS. This is useful if a deployment is necessary in a delegate account. 

The changes in the gradle file of the application will be as follows
## Before

beanstalk {
    profile = 'default'
    s3Endpoint = "s3-eu-west-1.amazonaws.com"
    beanstalkEndpoint = "elasticbeanstalk.eu-west-1.amazonaws.com"

```
deployments {
    staging {
        war = aaa.war
        application = 'appName'
        environment = 'appName-env'
    }

    prelive {
        war = aaa.war
        application = 'appName'
        environment = 'appName-prelive'
    }
}
```

}
## After

beanstalk {
    profile = 'default'
    s3Endpoint = "s3-eu-west-1.amazonaws.com"
    beanstalkEndpoint = "elasticbeanstalk.eu-west-1.amazonaws.com"

```
deployments {
    staging {
        war = aaa.war
        application = 'appName'
        environment = 'appName-env'
    }

    prelive {
        account = 'accountName'
        arnRole = 'arnRole'
        war = aaa.war
        application = 'appName'
        environment = 'appName-prelive'
    }
}
```

}
