### PR TITLE
Updates AWS SDK version to 1.11.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 ext {
-    awsApiVersion = '1.10.13'
+    awsApiVersion = '1.11.32'
 }
 
 dependencies {


### PR DESCRIPTION
Fixes issue where old version of AWS library conflicts and throws exception due to missing method when used alongside other plugins.
