### PR TITLE
Adds ability to specify prefix for the version string for EB

### DIFF
--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
@@ -6,6 +6,7 @@ public class BeanstalkDeployment {
     private String application;
     private String environment;
     private String template = "default";
+    private String versionPrefix = "";
     private Object war;
 
     public BeanstalkDeployment(String name) {
@@ -14,6 +15,14 @@ public class BeanstalkDeployment {
 
     public final String getName() {
         return name;
+    }
+
+    public String getVersionPrefix() {
+        return versionPrefix;
+    }
+
+    public void setVersionPrefix(String versionPrefix) {
+        this.versionPrefix = versionPrefix;
     }
 
     public String getApplication() {

--- a/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
@@ -20,11 +20,7 @@ public class DeployTask extends DefaultTask {
 
     @TaskAction
     protected void deploy() {
-        String versionLabel = getProject().getVersion().toString();
-        if (versionLabel.endsWith("-SNAPSHOT")) {
-            String timeLabel = new SimpleDateFormat("yyyyMMdd'.'HHmmss").format(new Date());
-            versionLabel = versionLabel.replace("SNAPSHOT", timeLabel); // Append time to get unique version label
-        }
+        String versionLabel = getVersionLabel();
 
         AWSCredentialsProviderChain credentialsProvider = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider(), new SystemPropertiesCredentialsProvider(), new ProfileCredentialsProvider(beanstalk.getProfile()));
 
@@ -32,6 +28,15 @@ public class DeployTask extends DefaultTask {
 
         File warFile = getProject().files(war).getSingleFile();
         deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), deployment.getTemplate(), versionLabel);
+    }
+
+    protected String getVersionLabel() {
+        String versionLabel = getProject().getVersion().toString();
+        if (versionLabel.endsWith("-SNAPSHOT")) {
+            String timeLabel = new SimpleDateFormat("yyyyMMdd'.'HHmmss").format(new Date());
+            versionLabel = versionLabel.replace("SNAPSHOT", timeLabel); // Append time to get unique version label
+        }
+        return deployment.getVersionPrefix() + versionLabel;
     }
 
     public void setBeanstalk(BeanstalkPluginExtension beanstalk) {

--- a/src/test/java/fi/evident/gradle/beanstalk/DeployTaskTest.java
+++ b/src/test/java/fi/evident/gradle/beanstalk/DeployTaskTest.java
@@ -1,0 +1,31 @@
+package fi.evident.gradle.beanstalk;
+
+import java.util.Map;
+import java.util.HashMap;
+import org.junit.Test;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+
+import static org.junit.Assert.assertTrue;
+
+public class DeployTaskTest {
+    @Test
+    public void versionShouldIncludePrefix() {
+        Project project = ProjectBuilder.builder().build();
+        project.setVersion("version");
+        Map<String, Object> params = new HashMap<>();
+        params.put("type", TestDeployTask.class);
+        TestDeployTask task = (TestDeployTask) project.task(params, "tasktest");
+        BeanstalkDeployment deployment = new BeanstalkDeployment("tasktest");
+        deployment.setVersionPrefix("test-");
+        task.setDeployment(deployment);
+
+        assertTrue(task.findVersionLabel().matches("test-version"));
+    }
+
+    public static class TestDeployTask extends DeployTask {
+        private String findVersionLabel() {
+            return getVersionLabel();
+        }
+    }
+}


### PR DESCRIPTION
We were having issues with a multi-module deployment to different environments within a single EB application. The plugin was generating the same version name for each module, which causes a conflict when used with a single EB application. With this change, an optional `versionPrefix` can be specified in the deployment configuration.