### PR TITLE
AWS instance profile is not used by plugin

### DIFF
--- a/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
@@ -1,6 +1,7 @@
 package fi.evident.gradle.beanstalk;
 
 import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
@@ -22,7 +23,7 @@ public class DeployTask extends DefaultTask {
     protected void deploy() {
         String versionLabel = getVersionLabel();
 
-        AWSCredentialsProviderChain credentialsProvider = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider(), new SystemPropertiesCredentialsProvider(), new ProfileCredentialsProvider(beanstalk.getProfile()));
+        AWSCredentialsProviderChain credentialsProvider = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider(), new SystemPropertiesCredentialsProvider(), new ProfileCredentialsProvider(beanstalk.getProfile()), new EC2ContainerCredentialsProviderWrapper());
 
         BeanstalkDeployer deployer = new BeanstalkDeployer(beanstalk.getS3Endpoint(), beanstalk.getBeanstalkEndpoint(), credentialsProvider);
 


### PR DESCRIPTION
Resolves AWS instance profile is not used by plugin (https://github.com/EvidentSolutions/gradle-beanstalk-plugin/issues/21)
