### PR TITLE
Allow uploading a new version without deploying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Next, configure some deployments in your `build.gradle`:
                 environment = "my-app-${project.version.replaceAll('\\.', '-')}"
                 template = 'default' // Saved configuration name to use to create each env
             }
+            // Example to upload a new version to an application without deploying it (to be able to
+            //  manually pick which environment to use)
+            upload {
+                file = tasks.war
+                application = 'my-app'
+            }
         }
     }
 

--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployer.java
@@ -40,7 +40,9 @@ public class BeanstalkDeployer {
 
         S3Location bundle = uploadCodeBundle(warFile);
         ApplicationVersionDescription version = createApplicationVersion(bundle, applicationName, versionLabel);
-        deployNewVersion(version.getVersionLabel(), environmentName, applicationName, templateName);
+        if (environmentName != null) {
+            deployNewVersion(version.getVersionLabel(), environmentName, applicationName, templateName);
+        }
         deleteOldVersions(applicationName);
     }
 


### PR DESCRIPTION
In some situations it would be nice to be able to automatically upload a new build to Beanstalk (this would be done by a CI server), but to manually select to which environment this new version is going to be deployed (none, one, multiple). As it turns out, this is very simple to achieve, by adding the bit of code in this PR: just don't deploy if the environment is not set!