### PR TITLE
Allow Zones for deployment

### DIFF
--- a/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/BeanstalkDeployment.java
@@ -9,6 +9,8 @@ public class BeanstalkDeployment {
     private String versionPrefix = "";
     private String versionSuffix = "";
     private Object file;
+    private String s3Endpoint;
+    private String beanstalkEndpoint;
 
     public BeanstalkDeployment(String name) {
         this.name = name;
@@ -74,5 +76,21 @@ public class BeanstalkDeployment {
 
     public Object getFile() {
         return file;
+    }
+
+    public String getS3Endpoint() {
+        return s3Endpoint;
+    }
+
+    public void setS3Endpoint(String s3Endpoint) {
+        this.s3Endpoint = s3Endpoint;
+    }
+
+    public String getBeanstalkEndpoint() {
+        return beanstalkEndpoint;
+    }
+
+    public void setBeanstalkEndpoint(String beanstalkEndpoint) {
+        this.beanstalkEndpoint = beanstalkEndpoint;
     }
 }

--- a/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
+++ b/src/main/java/fi/evident/gradle/beanstalk/DeployTask.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import static java.util.Optional.ofNullable;
+
 public class DeployTask extends DefaultTask {
 
     private BeanstalkPluginExtension beanstalk;
@@ -26,7 +28,9 @@ public class DeployTask extends DefaultTask {
 
         AWSCredentialsProviderChain credentialsProvider = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider(), new SystemPropertiesCredentialsProvider(), new ProfileCredentialsProvider(beanstalk.getProfile()), new EC2ContainerCredentialsProviderWrapper());
 
-        BeanstalkDeployer deployer = new BeanstalkDeployer(beanstalk.getS3Endpoint(), beanstalk.getBeanstalkEndpoint(), credentialsProvider);
+        BeanstalkDeployer deployer = new BeanstalkDeployer(ofNullable(deployment.getS3Endpoint()).orElse(beanstalk.getS3Endpoint()),
+                                                           ofNullable(deployment.getBeanstalkEndpoint()).orElse(beanstalk.getBeanstalkEndpoint()),
+                                                            credentialsProvider);
 
         File warFile = getProject().files(war).getSingleFile();
         deployer.deploy(warFile, deployment.getApplication(), deployment.getEnvironment(), deployment.getTemplate(), versionLabel);


### PR DESCRIPTION
Enable specific zones for deployment 

Ex:

```gradle
beanstalk {
    profile = 'default' 
    deployments {
        staging {
            s3Endpoint = "s3.us-east-1.amazonaws.com"
            beanstalkEndpoint = "elasticbeanstalk.us-east-1.amazonaws.com"
            file = tasks.bootJar
            application = '1234'
            environment = '1234'
            template = 'template' 
        }
        production {
            s3Endpoint = "s3.sa-east-1.amazonaws.com"
            beanstalkEndpoint = "elasticbeanstalk.sa-east-1.amazonaws.com"
            file = tasks.bootJar
            application = 'prod'
            environment = 'prod-env'
            template = 'template' 
        }
    }
}
```



